### PR TITLE
feat: implement --install and --cleanup flags for dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ npm-debug.log*
 
 # Documentation
 docs/
+
+# AI assistants
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -18,11 +18,8 @@ wdk-worklet-bundler init
 
 # 2. Edit wdk.config.js to configure your networks
 
-# 3. Install WDK modules
-npm install @tetherto/wdk @tetherto/wdk-wallet-evm-erc-4337
-
-# 4. Generate the bundle
-wdk-worklet-bundler generate
+# 3. Generate the bundle (--install auto-installs, --cleanup removes them after)
+wdk-worklet-bundler generate --install --cleanup
 ```
 
 ## Commands
@@ -42,12 +39,14 @@ wdk-worklet-bundler init --from-pear-wrk-wdk ./path  # Migrate from pear-wrk-wdk
 Generate the WDK bundle from your configuration.
 
 ```bash
-wdk-worklet-bundler generate                # Full build
-wdk-worklet-bundler generate --source-only  # Generate source files only (skip bare-pack)
-wdk-worklet-bundler generate --dry-run      # Preview what will be generated
-wdk-worklet-bundler generate --verbose      # Show detailed output
-wdk-worklet-bundler generate --no-types     # Skip TypeScript declaration generation
-wdk-worklet-bundler generate -c custom.config.js  # Use custom config file
+wdk-worklet-bundler generate                       # Full build
+wdk-worklet-bundler generate --install             # Auto-install missing dependencies
+wdk-worklet-bundler generate --install --cleanup   # Install, build, then remove dependencies
+wdk-worklet-bundler generate --source-only         # Generate source files only (skip bare-pack)
+wdk-worklet-bundler generate --dry-run             # Preview what will be generated
+wdk-worklet-bundler generate --verbose             # Show detailed output
+wdk-worklet-bundler generate --no-types            # Skip TypeScript declaration generation
+wdk-worklet-bundler generate -c custom.config.js   # Use custom config file
 ```
 
 ### `wdk-worklet-bundler validate`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,14 +20,18 @@ program
   .description('Generate WDK bundle from configuration')
   .option('-c, --config <path>', 'Path to config file')
   .option('--install', 'Auto-install missing dependencies')
+  .option('--cleanup', 'Remove installed dependencies after bundle is created (use with --install)')
   .option('--dry-run', 'Show what would be generated without building')
   .option('-v, --verbose', 'Show verbose output')
   .option('--no-types', 'Skip TypeScript declaration generation')
   .option('--source-only', 'Only generate source files (skip bare-pack)')
   .action(async (options) => {
     const { loadConfig } = await import('./config/loader')
-    const { validateDependencies } = await import('./validators/dependencies')
+    const { validateDependencies, installDependencies, uninstallDependencies } = await import('./validators/dependencies')
     const { generateBundle, generateSourceFiles } = await import('./bundler')
+
+    // Track packages installed by --install for potential cleanup
+    let installedPackages: string[] = []
 
     try {
       console.log('\n🔍 Reading configuration...\n')
@@ -35,7 +39,7 @@ program
       console.log(`  Config: ${config.configPath}`)
 
       console.log('\n📦 Checking dependencies...\n')
-      const validation = validateDependencies(config.modules, config.projectRoot)
+      let validation = validateDependencies(config.modules, config.projectRoot)
 
       for (const mod of validation.installed) {
         const version = mod.isLocal ? 'local' : `v${mod.version}`
@@ -46,9 +50,51 @@ program
         console.log(`  ✗ ${mod} — NOT INSTALLED`)
       }
 
-      if (!validation.valid && !options.sourceOnly) {
+      // Auto-install missing dependencies if --install flag is set
+      if (!validation.valid && options.install) {
+        console.log('\n📥 Installing missing dependencies...\n')
+
+        const installResult = installDependencies(validation.missing, config.projectRoot, {
+          verbose: options.verbose,
+        })
+
+        if (installResult.command) {
+          console.log(`  Running: ${installResult.command}\n`)
+        }
+
+        if (installResult.installed.length > 0) {
+          for (const pkg of installResult.installed) {
+            console.log(`  ✓ Installed ${pkg}`)
+          }
+          // Track installed packages for potential cleanup
+          installedPackages = installResult.installed
+        }
+
+        if (installResult.failed.length > 0) {
+          for (const pkg of installResult.failed) {
+            console.log(`  ✗ Failed to install ${pkg}`)
+          }
+        }
+
+        if (installResult.error && installResult.installed.length === 0) {
+          console.log(`\n❌ Installation failed: ${installResult.error}\n`)
+          process.exit(1)
+        }
+
+        // Re-validate after installation
+        validation = validateDependencies(config.modules, config.projectRoot)
+
+        if (!validation.valid && !options.sourceOnly) {
+          console.log('\n❌ Some dependencies are still missing after installation\n')
+          for (const mod of validation.missing) {
+            console.log(`  ✗ ${mod}`)
+          }
+          process.exit(1)
+        }
+      } else if (!validation.valid && !options.sourceOnly) {
         console.log('\n❌ Cannot generate bundle: missing dependencies\n')
         console.log(`  Run: npm install ${validation.missing.join(' ')}\n`)
+        console.log('  Or use --install to auto-install missing dependencies\n')
         console.log('  Or use --source-only to generate source files without bundling\n')
         process.exit(1)
       }
@@ -96,6 +142,32 @@ program
         console.log(`  Types: ${result.typesPath}`)
       }
       console.log(`  Duration: ${duration}s\n`)
+
+      // Cleanup installed dependencies if --cleanup flag is set
+      if (options.cleanup && installedPackages.length > 0) {
+        console.log('🧹 Cleaning up installed dependencies...\n')
+
+        const uninstallResult = uninstallDependencies(installedPackages, config.projectRoot, {
+          verbose: options.verbose,
+        })
+
+        if (uninstallResult.command) {
+          console.log(`  Running: ${uninstallResult.command}\n`)
+        }
+
+        if (uninstallResult.removed.length > 0) {
+          for (const pkg of uninstallResult.removed) {
+            console.log(`  ✓ Removed ${pkg}`)
+          }
+          console.log('')
+        }
+
+        if (!uninstallResult.success) {
+          console.log(`\n⚠️  Cleanup warning: ${uninstallResult.error}\n`)
+        }
+      } else if (options.cleanup && installedPackages.length === 0) {
+        console.log('ℹ️  No dependencies to clean up (nothing was installed by --install)\n')
+      }
     } catch (error) {
       console.error('\n❌ Error:', error instanceof Error ? error.message : error)
       process.exit(1)

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,8 @@ export { loadConfig } from './config/loader'
 export type { WdkConfig, ResolvedConfig, NetworkConfig } from './config/types'
 
 // Validators
-export { validateDependencies } from './validators/dependencies'
-export type { ModuleInfo, ValidationResult } from './validators/dependencies'
+export { validateDependencies, installDependencies, uninstallDependencies, detectPackageManager, generateInstallCommand, generateUninstallCommand } from './validators/dependencies'
+export type { ModuleInfo, ValidationResult, InstallResult, UninstallResult } from './validators/dependencies'
 
 // Bundler
 export { generateBundle, generateSourceFiles } from './bundler'

--- a/src/validators/dependencies.ts
+++ b/src/validators/dependencies.ts
@@ -144,3 +144,155 @@ export function generateInstallCommand(
       return `npm install ${packages.join(' ')}`;
   }
 }
+
+export interface InstallResult {
+  success: boolean;
+  command: string;
+  installed: string[];
+  failed: string[];
+  error?: string;
+}
+
+export interface UninstallResult {
+  success: boolean;
+  command: string;
+  removed: string[];
+  failed: string[];
+  error?: string;
+}
+
+/**
+ * Install missing dependencies
+ */
+export function installDependencies(
+  missing: string[],
+  projectRoot: string,
+  options: { verbose?: boolean } = {}
+): InstallResult {
+  const { execSync } = require('child_process');
+
+  // Filter out local paths - we can only install npm packages
+  const packages = missing.filter(
+    (m) => !m.startsWith('.') && !m.startsWith('/')
+  );
+
+  const localPaths = missing.filter(
+    (m) => m.startsWith('.') || m.startsWith('/')
+  );
+
+  if (packages.length === 0) {
+    return {
+      success: localPaths.length === 0,
+      command: '',
+      installed: [],
+      failed: localPaths,
+      error: localPaths.length > 0
+        ? `Cannot auto-install local paths: ${localPaths.join(', ')}`
+        : undefined,
+    };
+  }
+
+  const packageManager = detectPackageManager(projectRoot);
+  const command = generateInstallCommand(packages, packageManager);
+
+  try {
+    execSync(command, {
+      cwd: projectRoot,
+      stdio: options.verbose ? 'inherit' : 'pipe',
+    });
+
+    return {
+      success: localPaths.length === 0,
+      command,
+      installed: packages,
+      failed: localPaths,
+      error: localPaths.length > 0
+        ? `Cannot auto-install local paths: ${localPaths.join(', ')}`
+        : undefined,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      command,
+      installed: [],
+      failed: [...packages, ...localPaths],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Generate uninstall command for packages
+ */
+export function generateUninstallCommand(
+  packages: string[],
+  packageManager: 'npm' | 'yarn' | 'pnpm' = 'npm'
+): string {
+  // Filter out local paths
+  const npmPackages = packages.filter(
+    (m) => !m.startsWith('.') && !m.startsWith('/')
+  );
+
+  if (npmPackages.length === 0) {
+    return '';
+  }
+
+  switch (packageManager) {
+    case 'yarn':
+      return `yarn remove ${npmPackages.join(' ')}`;
+    case 'pnpm':
+      return `pnpm remove ${npmPackages.join(' ')}`;
+    default:
+      return `npm uninstall ${npmPackages.join(' ')}`;
+  }
+}
+
+/**
+ * Uninstall dependencies
+ */
+export function uninstallDependencies(
+  packages: string[],
+  projectRoot: string,
+  options: { verbose?: boolean } = {}
+): UninstallResult {
+  const { execSync } = require('child_process');
+
+  // Filter out local paths - we can only uninstall npm packages
+  const npmPackages = packages.filter(
+    (m) => !m.startsWith('.') && !m.startsWith('/')
+  );
+
+  if (npmPackages.length === 0) {
+    return {
+      success: true,
+      command: '',
+      removed: [],
+      failed: [],
+    };
+  }
+
+  const packageManager = detectPackageManager(projectRoot);
+  const command = generateUninstallCommand(npmPackages, packageManager);
+
+  try {
+    execSync(command, {
+      cwd: projectRoot,
+      stdio: options.verbose ? 'inherit' : 'pipe',
+    });
+
+    return {
+      success: true,
+      command,
+      removed: npmPackages,
+      failed: [],
+    };
+  } catch (error) {
+    return {
+      success: false,
+      command,
+      removed: [],
+      failed: npmPackages,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/tests/integration/cli.test.ts
+++ b/tests/integration/cli.test.ts
@@ -229,6 +229,107 @@ module.exports = {
       expect(output).toContain('missing dependencies');
     });
 
+    it('should suggest --install flag when dependencies are missing', () => {
+      const config = `
+module.exports = {
+  modules: {
+    core: '@tetherto/wdk',
+  },
+  networks: {
+    ethereum: {
+      module: 'core',
+      chainId: 1,
+      blockchain: 'ethereum',
+    },
+  },
+};
+`;
+      fs.writeFileSync(path.join(tempDir, 'wdk.config.js'), config);
+
+      const output = runCli('generate');
+
+      expect(output).toContain('--install');
+    });
+
+    it('should attempt install with --install flag', () => {
+      const config = `
+module.exports = {
+  modules: {
+    core: '@tetherto/wdk',
+  },
+  networks: {
+    ethereum: {
+      module: 'core',
+      chainId: 1,
+      blockchain: 'ethereum',
+    },
+  },
+};
+`;
+      fs.writeFileSync(path.join(tempDir, 'wdk.config.js'), config);
+      fs.writeFileSync(
+        path.join(tempDir, 'package.json'),
+        JSON.stringify({ name: 'test-project', version: '1.0.0' })
+      );
+
+      const output = runCli('generate --install');
+
+      // Should attempt to install
+      expect(output).toContain('Installing missing dependencies');
+    });
+
+    it('should warn about local paths that cannot be auto-installed', () => {
+      const config = `
+module.exports = {
+  modules: {
+    core: './local-wdk-module',
+  },
+  networks: {
+    ethereum: {
+      module: 'core',
+      chainId: 1,
+      blockchain: 'ethereum',
+    },
+  },
+};
+`;
+      fs.writeFileSync(path.join(tempDir, 'wdk.config.js'), config);
+
+      const output = runCli('generate --install');
+
+      expect(output).toContain('Failed to install');
+    });
+
+    it('should inform when --cleanup is used without --install', () => {
+      const config = `
+module.exports = {
+  modules: {
+    core: '@tetherto/wdk',
+  },
+  networks: {
+    ethereum: {
+      module: 'core',
+      chainId: 1,
+      blockchain: 'ethereum',
+    },
+  },
+};
+`;
+      fs.writeFileSync(path.join(tempDir, 'wdk.config.js'), config);
+
+      // Create fake node_modules so validation passes
+      const wdkPath = path.join(tempDir, 'node_modules', '@tetherto', 'wdk');
+      fs.mkdirSync(wdkPath, { recursive: true });
+      fs.writeFileSync(
+        path.join(wdkPath, 'package.json'),
+        JSON.stringify({ name: '@tetherto/wdk', version: '1.0.0' })
+      );
+
+      const output = runCli('generate --cleanup --dry-run');
+
+      expect(output).toContain('No dependencies to clean up');
+    });
+
     it('should generate source files with --source-only', () => {
       // Create a valid config
       const config = `

--- a/tests/unit/dependencies.test.ts
+++ b/tests/unit/dependencies.test.ts
@@ -6,6 +6,9 @@ import {
   validateDependencies,
   detectPackageManager,
   generateInstallCommand,
+  generateUninstallCommand,
+  installDependencies,
+  uninstallDependencies,
 } from '../../src/validators/dependencies';
 
 describe('Dependency Validator', () => {
@@ -210,6 +213,128 @@ describe('Dependency Validator', () => {
       const missing = ['./local-module', '/absolute/path'];
       const cmd = generateInstallCommand(missing, 'npm');
       expect(cmd).toBe('');
+    });
+  });
+
+  describe('installDependencies', () => {
+    it('should return error for local paths only', () => {
+      const result = installDependencies(['./local-module', '/absolute/path'], tempDir);
+
+      expect(result.success).toBe(false);
+      expect(result.command).toBe('');
+      expect(result.installed).toHaveLength(0);
+      expect(result.failed).toContain('./local-module');
+      expect(result.failed).toContain('/absolute/path');
+      expect(result.error).toContain('Cannot auto-install local paths');
+    });
+
+    it('should return success with no packages when array is empty', () => {
+      const result = installDependencies([], tempDir);
+
+      expect(result.success).toBe(true);
+      expect(result.command).toBe('');
+      expect(result.installed).toHaveLength(0);
+      expect(result.failed).toHaveLength(0);
+    });
+
+    it('should detect package manager and generate correct command', () => {
+      // Create pnpm lock file
+      fs.writeFileSync(path.join(tempDir, 'pnpm-lock.yaml'), '');
+
+      // This will fail because the package doesn't exist, but we can check the command
+      const result = installDependencies(['nonexistent-package-xyz'], tempDir);
+
+      expect(result.command).toBe('pnpm add nonexistent-package-xyz');
+      expect(result.success).toBe(false);
+    });
+
+    it('should separate npm packages from local paths', () => {
+      const result = installDependencies(
+        ['@tetherto/wdk', './local-module'],
+        tempDir
+      );
+
+      // The npm install will fail, but local paths should be in failed
+      expect(result.failed).toContain('./local-module');
+      expect(result.command).toBe('npm install @tetherto/wdk');
+    });
+
+    it('should report partial success with local path warning', () => {
+      // Create a fake package.json to make npm happy
+      fs.writeFileSync(
+        path.join(tempDir, 'package.json'),
+        JSON.stringify({ name: 'test', version: '1.0.0' })
+      );
+
+      const result = installDependencies(['./missing-local'], tempDir);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Cannot auto-install local paths');
+    });
+  });
+
+  describe('generateUninstallCommand', () => {
+    it('should generate npm uninstall command', () => {
+      const packages = ['@tetherto/wdk', '@tetherto/wdk-wallet-evm-erc-4337'];
+      const cmd = generateUninstallCommand(packages, 'npm');
+      expect(cmd).toBe('npm uninstall @tetherto/wdk @tetherto/wdk-wallet-evm-erc-4337');
+    });
+
+    it('should generate yarn remove command', () => {
+      const packages = ['@tetherto/wdk'];
+      const cmd = generateUninstallCommand(packages, 'yarn');
+      expect(cmd).toBe('yarn remove @tetherto/wdk');
+    });
+
+    it('should generate pnpm remove command', () => {
+      const packages = ['@tetherto/wdk'];
+      const cmd = generateUninstallCommand(packages, 'pnpm');
+      expect(cmd).toBe('pnpm remove @tetherto/wdk');
+    });
+
+    it('should filter out local paths', () => {
+      const packages = ['@tetherto/wdk', './local-module', '/absolute/path'];
+      const cmd = generateUninstallCommand(packages, 'npm');
+      expect(cmd).toBe('npm uninstall @tetherto/wdk');
+    });
+
+    it('should return empty string if only local paths', () => {
+      const packages = ['./local-module', '/absolute/path'];
+      const cmd = generateUninstallCommand(packages, 'npm');
+      expect(cmd).toBe('');
+    });
+  });
+
+  describe('uninstallDependencies', () => {
+    it('should return success with empty array', () => {
+      const result = uninstallDependencies([], tempDir);
+
+      expect(result.success).toBe(true);
+      expect(result.command).toBe('');
+      expect(result.removed).toHaveLength(0);
+      expect(result.failed).toHaveLength(0);
+    });
+
+    it('should skip local paths', () => {
+      const result = uninstallDependencies(['./local-module'], tempDir);
+
+      expect(result.success).toBe(true);
+      expect(result.command).toBe('');
+      expect(result.removed).toHaveLength(0);
+    });
+
+    it('should detect package manager for uninstall', () => {
+      // Create pnpm lock file
+      fs.writeFileSync(path.join(tempDir, 'pnpm-lock.yaml'), '');
+      fs.writeFileSync(
+        path.join(tempDir, 'package.json'),
+        JSON.stringify({ name: 'test', version: '1.0.0' })
+      );
+
+      // This will fail because the package doesn't exist, but we can check the command
+      const result = uninstallDependencies(['nonexistent-package-xyz'], tempDir);
+
+      expect(result.command).toBe('pnpm remove nonexistent-package-xyz');
     });
   });
 });


### PR DESCRIPTION
Add automatic dependency installation and cleanup functionality to the generate command:

- --install: Auto-detects package manager (npm/yarn/pnpm) and installs missing dependencies before bundling
- --cleanup: Removes dependencies installed by --install after the bundle is successfully created

This enables a streamlined workflow where dependencies are only present during the build process, keeping the project clean afterward.

Also includes:
- Unit tests for install/uninstall functions
- Integration tests for CLI flags
- Updated README with new command examples