### PR TITLE
fix: link bare-posix native addon

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,7 @@ export const BARE_LINK_MODULES = [
   'bare-abort', 'bare-buffer', 'bare-channel', 'bare-crypto', 'bare-dns',
   'bare-fs', 'bare-hrtime', 'bare-inspect', 'bare-logger',
   'bare-module', 'bare-module-lexer', 'bare-os', 'bare-performance',
-  'bare-pipe', 'bare-realm', 'bare-repl', 'bare-signals', 'bare-stdio',
+  'bare-pipe', 'bare-posix', 'bare-realm', 'bare-repl', 'bare-signals', 'bare-stdio',
   'bare-structured-clone', 'bare-subprocess', 'bare-system-logger',
   'bare-tcp', 'bare-thread', 'bare-timers', 'bare-tls', 'bare-tty',
   'bare-type', 'bare-url', 'bare-zlib',


### PR DESCRIPTION
# Description

Adds `bare-posix` to `BARE_LINK_MODULES` in `src/constants.ts`, so `bare-link` builds its native framework and includes it in the generated `addons.yml` for all platforms (iOS, macOS, Android).

## Motivation and Context

`bare-process@4.5.0` (released 2026-06-22) added `bare-posix ^1.0.1` as a dependency with an unconditional top-level `require`. Since `bare-process` is part of the `bare-node-runtime` polyfill chain, every bundle generated with fresh dependencies now requires the `bare-posix` native addon at boot — but the bundler's hardcoded module list never linked it. The worklet then aborts during startup (SIGABRT) with an `ADDON_NOT_FOUND` error that is invisible from the host app:

```
Uncaught AddonError: ADDON_NOT_FOUND: Cannot find addon '.'
imported from '.../node_modules/bare-posix/binding.js'
Candidates:
- linked:bare-posix.1.0.1.framework/bare-posix.1.0.1
```

This is what broke the JSON-RPC Swift stack after the recent dependency refresh: bundles built after Jun 22 reference the addon, the addon zips don't contain it, and the app/tests crash on worklet start. Android is only unaffected while its bundles are built from pre-4.5.0 lockfiles — the first regeneration with fresh deps hits the same crash, so this fix covers all platforms. Verified end-to-end: with the regenerated addons (32 xcframeworks incl. `bare-posix.1.0.1`) the worklet boots and the wdk-core-swift suite passes 24/24 on macOS.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
