### PR TITLE
fix: skip and defer optional peer dependencies, handle non-TTY installs (postinstall no longer fails on @ledgerhq/ledger-bitcoin)

### DIFF
--- a/src/bundler/index.ts
+++ b/src/bundler/index.ts
@@ -24,7 +24,6 @@ export interface GenerateBundleOptions {
   silent?: boolean
   skipTypes?: boolean
   skipGeneration?: boolean
-  /** Defer missing optional peer deps to runtime instead of failing (default: true) */
   deferOptionalPeers?: boolean
 }
 
@@ -45,7 +44,6 @@ interface BarePackOptions {
   targets: string[]
   cwd: string
   verbose?: boolean
-  /** Module specifiers whose resolution is deferred to runtime (missing optional peers) */
   defer?: string[]
 }
 

--- a/src/bundler/index.ts
+++ b/src/bundler/index.ts
@@ -11,6 +11,8 @@ import { generateEntryPoint } from '../generators/entry'
 import { generateJsonRpcEntryPoint } from '../generators/entry-jsonrpc'
 import { linkAddons } from './addons'
 import { convertBundleEsmToCjs } from './convert-esm-to-cjs'
+import { validateDependencies, findMissingOptionalPeers } from '../validators/dependencies'
+import { getPackageList } from '../config/packages'
 import { DEFAULT_BUNDLE_BUILD_HOSTS, DEFAULT_OUTPUT_DIR, DEFAULT_ENTRY_FILENAME } from '../constants'
 
 export type { LinkAddonsOptions, LinkAddonsResult } from './addons'
@@ -41,6 +43,8 @@ interface BarePackOptions {
   targets: string[]
   cwd: string
   verbose?: boolean
+  /** Module specifiers whose resolution is deferred to runtime (missing optional peers) */
+  defer?: string[]
 }
 
 class MissingModuleError extends Error {
@@ -54,7 +58,7 @@ class MissingModuleError extends Error {
  * Run bare-pack to create the final bundle
  */
 function runBarePack (options: BarePackOptions): void {
-  const { entryPath, outputPath, importsPath, targets, cwd, verbose } = options
+  const { entryPath, outputPath, importsPath, targets, cwd, verbose, defer } = options
 
   // Build args array to prevent command injection
   const args = ['--no-install', 'bare-pack']
@@ -64,6 +68,13 @@ function runBarePack (options: BarePackOptions): void {
       throw new Error(`Invalid target format: ${target}`)
     }
     args.push('--host', target)
+  }
+  for (const specifier of defer ?? []) {
+    // Validate npm package name format (optionally scoped)
+    if (!/^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/i.test(specifier)) {
+      throw new Error(`Invalid defer specifier format: ${specifier}`)
+    }
+    args.push('--defer', specifier)
   }
   args.push('--linked', '--imports', importsPath, '--out', outputPath, entryPath)
 
@@ -226,6 +237,15 @@ export async function generateBundle (
     if (verbose) log('  Running bare-pack...')
     const targets = config.options?.targets || getDefaultHosts()
 
+    // Missing peers marked optional via peerDependenciesMeta (e.g.
+    // @ledgerhq/ledger-bitcoin for @bitcoinerlab/descriptors) are deferred so
+    // bare-pack doesn't fail statically resolving imports the app never uses.
+    const { installed } = validateDependencies(getPackageList(config), config.projectRoot)
+    const deferredPeers = findMissingOptionalPeers(installed, config.projectRoot, { verbose })
+    if (deferredPeers.length > 0) {
+      log(`  Deferring missing optional peer dependencies: ${deferredPeers.join(', ')}`)
+    }
+
     try {
       runBarePack({
         entryPath,
@@ -233,7 +253,8 @@ export async function generateBundle (
         importsPath,
         targets,
         cwd: config.projectRoot,
-        verbose
+        verbose,
+        defer: deferredPeers
       })
     } catch (barePackError) {
       // Check if we identified a missing module

--- a/src/bundler/index.ts
+++ b/src/bundler/index.ts
@@ -24,6 +24,8 @@ export interface GenerateBundleOptions {
   silent?: boolean
   skipTypes?: boolean
   skipGeneration?: boolean
+  /** Defer missing optional peer deps to runtime instead of failing (default: true) */
+  deferOptionalPeers?: boolean
 }
 
 export interface GenerateBundleResult {
@@ -240,10 +242,15 @@ export async function generateBundle (
     // Missing peers marked optional via peerDependenciesMeta (e.g.
     // @ledgerhq/ledger-bitcoin for @bitcoinerlab/descriptors) are deferred so
     // bare-pack doesn't fail statically resolving imports the app never uses.
-    const { installed } = validateDependencies(getPackageList(config), config.projectRoot)
-    const deferredPeers = findMissingOptionalPeers(installed, config.projectRoot, { verbose })
-    if (deferredPeers.length > 0) {
-      log(`  Deferring missing optional peer dependencies: ${deferredPeers.join(', ')}`)
+    // --no-defer-optional-peers disables this for apps that use those
+    // features and want to find out at build time instead of runtime.
+    let deferredPeers: string[] = []
+    if (options.deferOptionalPeers !== false) {
+      const { installed } = validateDependencies(getPackageList(config), config.projectRoot)
+      deferredPeers = findMissingOptionalPeers(installed, config.projectRoot, { verbose })
+      if (deferredPeers.length > 0) {
+        log(`  Deferring missing optional peer dependencies: ${deferredPeers.join(', ')}`)
+      }
     }
 
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -104,15 +104,24 @@ program
     const {
       validateDependencies,
       installDependencies,
-      checkOptionalPeerDependencies
+      checkOptionalPeerDependencies,
+      detectPackageManager,
+      generateInstallCommand
     } = await import('./validators/dependencies')
     const { generateBundle, generateSourceFiles } = await import('./bundler')
 
     // Track packages installed by --install for potential cleanup
     const installedPackages: string[] = []
 
-    // Helper for prompts
-    const promptYesNo = async (question: string): Promise<boolean> => {
+    // Helper for prompts. Without a TTY (npm postinstall, CI) readline's
+    // callback never fires and node exits 0 silently, so answer with the
+    // provided default instead of prompting.
+    const promptYesNo = async (question: string, nonInteractiveDefault = false): Promise<boolean> => {
+      if (!process.stdin.isTTY) {
+        console.log(`${question} [Y/n] — non-interactive environment detected, assuming '${nonInteractiveDefault ? 'yes' : 'no'}'`)
+        return nonInteractiveDefault
+      }
+
       const readline = await import('readline')
       const rl = readline.createInterface({
         input: process.stdin,
@@ -120,9 +129,16 @@ program
       })
 
       return await new Promise((resolve) => {
+        let answered = false
         rl.question(`${question} [Y/n] `, (answer) => {
+          answered = true
           rl.close()
           resolve(answer.toLowerCase() !== 'n')
+        })
+        // stdin can still end mid-prompt (piped input); don't hang or
+        // silently drain the event loop.
+        rl.on('close', () => {
+          if (!answered) resolve(nonInteractiveDefault)
         })
       })
     }
@@ -195,6 +211,7 @@ program
           }
         } else if (!options.sourceOnly) {
           console.log('\n❌ Cannot proceed without core dependencies.')
+          console.log('   Install them manually or re-run with --install.\n')
           process.exit(1)
         }
       }
@@ -206,7 +223,7 @@ program
 
         if (missingPeers.length > 0) {
           console.log('\n🧩 Checking peer dependencies...\n')
-          console.log('  The following optional peer dependencies were found in your dependency tree.')
+          console.log('  The following peer dependencies are missing from your dependency tree.')
           console.log('  They are likely required for the worklet bundle to function correctly.\n')
 
           const packagesToInstall: string[] = []
@@ -239,7 +256,7 @@ program
           let shouldInstallPeers = options.install
 
           if (!shouldInstallPeers) {
-            console.log('\n⚠️  Missing optional peer dependencies.')
+            console.log('\n⚠️  Missing peer dependencies.')
             shouldInstallPeers = await promptYesNo('Would you like to install them now?')
           }
 
@@ -254,6 +271,10 @@ program
             } else {
               console.log(`\n⚠️  Warning: Failed to install some peer dependencies: ${result.error}`)
             }
+          } else {
+            const installCmd = generateInstallCommand(packagesToInstall, detectPackageManager(config.projectRoot))
+            console.log('\n⚠️  Skipping peer dependency installation. If the bundle fails, install them manually:\n')
+            console.log(`   ${installCmd}\n`)
           }
         }
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,8 +102,6 @@ program
           rl.close()
           resolve(answer.toLowerCase() !== 'n')
         })
-        // stdin can still end mid-prompt (piped input); don't hang or
-        // silently drain the event loop.
         rl.on('close', () => {
           if (!answered) resolve(nonInteractiveDefault)
         })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@ interface GenerateOptions {
   skipLinkAddons?: boolean
   platforms?: string
   esmToCjs?: boolean
+  deferOptionalPeers?: boolean
 }
 
 interface InitOptions {
@@ -64,6 +65,7 @@ program
   .option('--skip-link-addons', 'Skip bare-link addon linking (overrides jsonrpc default)')
   .option('--platforms <platforms>', 'Comma-separated platforms for addons: ios,macos,android')
   .option('--no-esm-to-cjs', 'Skip ESM to CJS conversion (for V8 runtimes like Android)')
+  .option('--no-defer-optional-peers', 'Fail on missing optional peer deps (e.g. Ledger support) instead of deferring them to runtime')
   .action(async (options: GenerateOptions) => {
     const { loadConfig } = await import('./config/loader')
     const {
@@ -268,7 +270,8 @@ program
         dryRun: options.dryRun,
         verbose: options.verbose,
         skipTypes: !options.types,
-        skipGeneration: options.skipGeneration
+        skipGeneration: options.skipGeneration,
+        deferOptionalPeers: options.deferOptionalPeers
       })
 
       if (!result.success) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import fs from 'fs'
 import path from 'path'
 import { DEFAULT_BUNDLE_BUILD_HOSTS, DEFAULT_BUNDLE_PATH, DEFAULT_TYPES_PATH, DEFAULT_OUTPUT_DIR } from './constants'
 import { printBanner } from './utils/banner'
-import type { WdkBundleConfig } from './config/types'
+import { getPackageList } from './config/packages'
 import pkg from '../package.json'
 
 interface GenerateOptions {
@@ -47,41 +47,6 @@ interface CleanOptions {
 const program = new Command()
 
 program.name('wdk-worklet-bundler').description('CLI tool for generating WDK worklet bundles').version(pkg.version)
-
-function getPackageList (config: WdkBundleConfig): string[] {
-  const packages = new Set<string>()
-
-  // Add core (always required implicitly, unless overriden/preloaded logic changes)
-  // For validation, we should probably check it.
-  packages.add('@tetherto/wdk')
-  packages.add('bare-node-runtime')
-
-  if (config.networks) {
-    for (const net of Object.values(config.networks)) {
-      if (net.package) packages.add(net.package)
-    }
-  }
-
-  if (config.protocols != null) {
-    for (const protocol of Object.values(config.protocols)) {
-      if (protocol?.package) packages.add(protocol.package)
-    }
-  }
-
-  if (config.modules != null) {
-    for (const mod of Object.values(config.modules)) {
-      if (mod && mod.package) packages.add(mod.package)
-    }
-  }
-
-  if (config.preloadModules != null) {
-    for (const mod of config.preloadModules) {
-      packages.add(mod)
-    }
-  }
-
-  return Array.from(packages)
-}
 
 program
   .command('generate')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,7 +71,7 @@ program
     const {
       validateDependencies,
       installDependencies,
-      checkOptionalPeerDependencies,
+      findMissingRequiredPeers,
       detectPackageManager,
       generateInstallCommand
     } = await import('./validators/dependencies')
@@ -182,18 +182,18 @@ program
       }
 
       if (validation.valid && !options.sourceOnly) {
-        const missingPeers = checkOptionalPeerDependencies(validation.installed, config.projectRoot, {
+        const missingRequiredPeers = findMissingRequiredPeers(validation.installed, config.projectRoot, {
           verbose: options.verbose
         })
 
-        if (missingPeers.length > 0) {
+        if (missingRequiredPeers.length > 0) {
           console.log('\n🧩 Checking peer dependencies...\n')
           console.log('  The following peer dependencies are missing from your dependency tree.')
           console.log('  They are likely required for the worklet bundle to function correctly.\n')
 
           const packagesToInstall: string[] = []
 
-          for (const peer of missingPeers) {
+          for (const peer of missingRequiredPeers) {
             // Determine install version
             const ranges = [...new Set(peer.sources.map(s => s.range))]
             const isSingle = ranges.length === 1

--- a/src/config/packages.ts
+++ b/src/config/packages.ts
@@ -1,0 +1,40 @@
+/**
+ * Derive the full list of packages a config depends on
+ */
+
+import type { WdkBundleConfig } from './types'
+
+export function getPackageList (config: WdkBundleConfig): string[] {
+  const packages = new Set<string>()
+
+  // Add core (always required implicitly, unless overriden/preloaded logic changes)
+  // For validation, we should probably check it.
+  packages.add('@tetherto/wdk')
+  packages.add('bare-node-runtime')
+
+  if (config.networks) {
+    for (const net of Object.values(config.networks)) {
+      if (net.package) packages.add(net.package)
+    }
+  }
+
+  if (config.protocols != null) {
+    for (const protocol of Object.values(config.protocols)) {
+      if (protocol?.package) packages.add(protocol.package)
+    }
+  }
+
+  if (config.modules != null) {
+    for (const mod of Object.values(config.modules)) {
+      if (mod && mod.package) packages.add(mod.package)
+    }
+  }
+
+  if (config.preloadModules != null) {
+    for (const mod of config.preloadModules) {
+      packages.add(mod)
+    }
+  }
+
+  return Array.from(packages)
+}

--- a/src/validators/dependencies.ts
+++ b/src/validators/dependencies.ts
@@ -114,13 +114,19 @@ export interface PeerScanResult {
   missingOptional: string[]
 }
 
-export function checkOptionalPeerDependencies (
+export function findMissingRequiredPeers (
   installedModules: ModuleInfo[],
   projectRoot: string,
   options: { verbose?: boolean } = {}
 ): MissingPeer[] {
   return scanPeerDependencies(installedModules, projectRoot, options).missing
 }
+
+/**
+ * @deprecated Use findMissingRequiredPeers — since optional-marked peers are
+ * filtered out, this returns only the required missing peers.
+ */
+export const checkOptionalPeerDependencies = findMissingRequiredPeers
 
 export function findMissingOptionalPeers (
   installedModules: ModuleInfo[],
@@ -186,7 +192,18 @@ export function scanPeerDependencies (
       const peerNames = new Set([...Object.keys(peerDeps), ...Object.keys(peerMeta)])
 
       for (const peerName of peerNames) {
-        const range = peerDeps[peerName] ?? '*'
+        const declaredRange = peerDeps[peerName]
+        const isOptional = peerMeta[peerName]?.optional === true
+
+        // A peerDependenciesMeta entry alone declares nothing — only honor
+        // meta-only names (e.g. follow-redirects → debug) when they are
+        // explicitly marked optional.
+        if (declaredRange == null && !isOptional) {
+          log(`  [scan] Skipping meta-only non-optional peer: ${peerName}`)
+          continue
+        }
+
+        const range = declaredRange ?? '*'
 
         if (IGNORED_PREFIXES.some(prefix => peerName.startsWith(prefix)) || peerName === 'react-native') {
           log(`  [scan] Skipping ignored peer: ${peerName}`)
@@ -201,7 +218,7 @@ export function scanPeerDependencies (
           // only needed for opt-in features (e.g. Ledger hardware signing
           // in @bitcoinerlab/descriptors) — never report them as missing,
           // but track them so bare-pack can defer their resolution.
-          if (peerMeta[peerName]?.optional === true) {
+          if (isOptional) {
             log(`  [scan] Optional peer not installed, will defer: ${peerName}`)
             missingOptional.add(peerName)
             continue
@@ -261,7 +278,7 @@ export function scanPeerDependencies (
 
   return {
     missing: Array.from(missingPeers.values()),
-    missingOptional: Array.from(missingOptional)
+    missingOptional: Array.from(missingOptional).filter(name => !missingPeers.has(name))
   }
 }
 

--- a/src/validators/dependencies.ts
+++ b/src/validators/dependencies.ts
@@ -7,6 +7,7 @@ interface PackageJson {
   version: string
   dependencies?: Record<string, string>
   peerDependencies?: Record<string, string>
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>
 }
 
 export interface ModuleInfo {
@@ -165,6 +166,14 @@ export function checkOptionalPeerDependencies (
         const peerInfo = resolveModule(peerName, projectRoot)
 
         if (peerInfo == null) {
+          // Peers explicitly marked optional via peerDependenciesMeta are
+          // only needed for opt-in features (e.g. Ledger hardware signing
+          // in @bitcoinerlab/descriptors) — never report them as missing.
+          if (pkg.peerDependenciesMeta?.[peerName]?.optional === true) {
+            log(`  [scan] Skipping optional peer (peerDependenciesMeta): ${peerName}`)
+            continue
+          }
+
           log(`  [scan] Missing peer: ${peerName} (required by ${currentName})`)
 
           if (!missingPeers.has(peerName)) {

--- a/src/validators/dependencies.ts
+++ b/src/validators/dependencies.ts
@@ -110,9 +110,7 @@ export interface MissingPeer {
 }
 
 export interface PeerScanResult {
-  /** Missing peers that are NOT marked optional — likely needed at runtime */
   missing: MissingPeer[]
-  /** Missing peers marked optional via peerDependenciesMeta — safe to defer */
   missingOptional: string[]
 }
 

--- a/src/validators/dependencies.ts
+++ b/src/validators/dependencies.ts
@@ -109,12 +109,36 @@ export interface MissingPeer {
   }>
 }
 
+export interface PeerScanResult {
+  /** Missing peers that are NOT marked optional — likely needed at runtime */
+  missing: MissingPeer[]
+  /** Missing peers marked optional via peerDependenciesMeta — safe to defer */
+  missingOptional: string[]
+}
+
 export function checkOptionalPeerDependencies (
   installedModules: ModuleInfo[],
   projectRoot: string,
   options: { verbose?: boolean } = {}
 ): MissingPeer[] {
+  return scanPeerDependencies(installedModules, projectRoot, options).missing
+}
+
+export function findMissingOptionalPeers (
+  installedModules: ModuleInfo[],
+  projectRoot: string,
+  options: { verbose?: boolean } = {}
+): string[] {
+  return scanPeerDependencies(installedModules, projectRoot, options).missingOptional
+}
+
+export function scanPeerDependencies (
+  installedModules: ModuleInfo[],
+  projectRoot: string,
+  options: { verbose?: boolean } = {}
+): PeerScanResult {
   const missingPeers = new Map<string, MissingPeer>()
+  const missingOptional = new Set<string>()
   const visitedPaths = new Set<string>()
   const queue: Array<{ path: string, name: string }> = installedModules.map(m => ({ path: m.path, name: m.name }))
 
@@ -156,7 +180,16 @@ export function checkOptionalPeerDependencies (
       const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as PackageJson
 
       const peerDeps: Record<string, string> = pkg.peerDependencies ?? {}
-      for (const [peerName, range] of Object.entries(peerDeps)) {
+      const peerMeta = pkg.peerDependenciesMeta ?? {}
+
+      // Some packages (e.g. follow-redirects) declare an optional peer only
+      // in peerDependenciesMeta, without a peerDependencies entry — scan the
+      // union of both fields.
+      const peerNames = new Set([...Object.keys(peerDeps), ...Object.keys(peerMeta)])
+
+      for (const peerName of peerNames) {
+        const range = peerDeps[peerName] ?? '*'
+
         if (IGNORED_PREFIXES.some(prefix => peerName.startsWith(prefix)) || peerName === 'react-native') {
           log(`  [scan] Skipping ignored peer: ${peerName}`)
           continue
@@ -168,9 +201,11 @@ export function checkOptionalPeerDependencies (
         if (peerInfo == null) {
           // Peers explicitly marked optional via peerDependenciesMeta are
           // only needed for opt-in features (e.g. Ledger hardware signing
-          // in @bitcoinerlab/descriptors) — never report them as missing.
-          if (pkg.peerDependenciesMeta?.[peerName]?.optional === true) {
-            log(`  [scan] Skipping optional peer (peerDependenciesMeta): ${peerName}`)
+          // in @bitcoinerlab/descriptors) — never report them as missing,
+          // but track them so bare-pack can defer their resolution.
+          if (peerMeta[peerName]?.optional === true) {
+            log(`  [scan] Optional peer not installed, will defer: ${peerName}`)
+            missingOptional.add(peerName)
             continue
           }
 
@@ -226,7 +261,10 @@ export function checkOptionalPeerDependencies (
     }
   }
 
-  return Array.from(missingPeers.values())
+  return {
+    missing: Array.from(missingPeers.values()),
+    missingOptional: Array.from(missingOptional)
+  }
 }
 
 export function detectPackageManager (

--- a/tests/unit/dependencies.test.ts
+++ b/tests/unit/dependencies.test.ts
@@ -10,7 +10,9 @@ import {
   installDependencies,
   uninstallDependencies,
   checkOptionalPeerDependencies,
-  findMissingOptionalPeers
+  findMissingRequiredPeers,
+  findMissingOptionalPeers,
+  scanPeerDependencies
 } from '../../src/validators/dependencies'
 
 describe('Dependency Validator', () => {
@@ -279,6 +281,63 @@ describe('Dependency Validator', () => {
       )
 
       expect(deferred).toEqual([])
+    })
+
+    it('should never defer a peer required elsewhere (required scanned first)', () => {
+      const requirerPath = writeModule('pkg-requirer', {
+        peerDependencies: { 'shared-peer': '^4.0.0' }
+      })
+      const optionalPath = writeModule('pkg-optional', {
+        peerDependencies: { 'shared-peer': '*' },
+        peerDependenciesMeta: { 'shared-peer': { optional: true } }
+      })
+      const requirer = { name: 'pkg-requirer', path: requirerPath, version: '1.0.0', isLocal: false }
+      const optional = { name: 'pkg-optional', path: optionalPath, version: '1.0.0', isLocal: false }
+
+      const result = scanPeerDependencies([requirer, optional], tempDir)
+
+      expect(result.missingOptional).toEqual([])
+      expect(result.missing).toHaveLength(1)
+      expect(result.missing[0].name).toBe('shared-peer')
+      // Only the actual requirer is listed as a source — no '*' range pollution
+      expect(result.missing[0].sources).toEqual([{ parent: 'pkg-requirer', range: '^4.0.0' }])
+    })
+
+    it('should never defer a peer required elsewhere (optional scanned first)', () => {
+      const requirerPath = writeModule('pkg-requirer', {
+        peerDependencies: { 'shared-peer': '^4.0.0' }
+      })
+      const optionalPath = writeModule('pkg-optional', {
+        peerDependencies: { 'shared-peer': '*' },
+        peerDependenciesMeta: { 'shared-peer': { optional: true } }
+      })
+      const requirer = { name: 'pkg-requirer', path: requirerPath, version: '1.0.0', isLocal: false }
+      const optional = { name: 'pkg-optional', path: optionalPath, version: '1.0.0', isLocal: false }
+
+      const result = scanPeerDependencies([optional, requirer], tempDir)
+
+      expect(result.missingOptional).toEqual([])
+      expect(result.missing).toHaveLength(1)
+      expect(result.missing[0].name).toBe('shared-peer')
+      expect(result.missing[0].sources).toEqual([{ parent: 'pkg-requirer', range: '^4.0.0' }])
+    })
+
+    it('should ignore meta-only peers not marked optional', () => {
+      const modulePath = writeModule('weird-pkg', {
+        peerDependenciesMeta: { 'not-really-a-peer': {} }
+      })
+
+      const result = scanPeerDependencies(
+        [{ name: 'weird-pkg', path: modulePath, version: '1.0.0', isLocal: false }],
+        tempDir
+      )
+
+      expect(result.missing).toHaveLength(0)
+      expect(result.missingOptional).toHaveLength(0)
+    })
+
+    it('should keep checkOptionalPeerDependencies as alias of findMissingRequiredPeers', () => {
+      expect(checkOptionalPeerDependencies).toBe(findMissingRequiredPeers)
     })
 
     it('should skip ignored peer prefixes', () => {

--- a/tests/unit/dependencies.test.ts
+++ b/tests/unit/dependencies.test.ts
@@ -9,7 +9,8 @@ import {
   generateUninstallCommand,
   installDependencies,
   uninstallDependencies,
-  checkOptionalPeerDependencies
+  checkOptionalPeerDependencies,
+  findMissingOptionalPeers
 } from '../../src/validators/dependencies'
 
 describe('Dependency Validator', () => {
@@ -231,6 +232,53 @@ describe('Dependency Validator', () => {
       )
 
       expect(missing).toHaveLength(0)
+    })
+
+    it('should list missing optional peers for deferral via findMissingOptionalPeers', () => {
+      const modulePath = writeModule('@bitcoinerlab/descriptors', {
+        peerDependencies: { '@ledgerhq/ledger-bitcoin': '^0.3.1' },
+        peerDependenciesMeta: { '@ledgerhq/ledger-bitcoin': { optional: true } }
+      })
+
+      const deferred = findMissingOptionalPeers(
+        [{ name: '@bitcoinerlab/descriptors', path: modulePath, version: '1.0.0', isLocal: false }],
+        tempDir
+      )
+
+      expect(deferred).toEqual(['@ledgerhq/ledger-bitcoin'])
+    })
+
+    it('should find optional peers declared only in peerDependenciesMeta', () => {
+      // follow-redirects style: no peerDependencies entry at all
+      const modulePath = writeModule('follow-redirects', {
+        peerDependenciesMeta: { debug: { optional: true } }
+      })
+
+      const deferred = findMissingOptionalPeers(
+        [{ name: 'follow-redirects', path: modulePath, version: '1.0.0', isLocal: false }],
+        tempDir
+      )
+
+      expect(deferred).toEqual(['debug'])
+      expect(checkOptionalPeerDependencies(
+        [{ name: 'follow-redirects', path: modulePath, version: '1.0.0', isLocal: false }],
+        tempDir
+      )).toHaveLength(0)
+    })
+
+    it('should not list installed optional peers for deferral', () => {
+      const modulePath = writeModule('@bitcoinerlab/descriptors', {
+        peerDependencies: { '@ledgerhq/ledger-bitcoin': '^0.3.1' },
+        peerDependenciesMeta: { '@ledgerhq/ledger-bitcoin': { optional: true } }
+      })
+      writeModule('@ledgerhq/ledger-bitcoin', {})
+
+      const deferred = findMissingOptionalPeers(
+        [{ name: '@bitcoinerlab/descriptors', path: modulePath, version: '1.0.0', isLocal: false }],
+        tempDir
+      )
+
+      expect(deferred).toEqual([])
     })
 
     it('should skip ignored peer prefixes', () => {

--- a/tests/unit/dependencies.test.ts
+++ b/tests/unit/dependencies.test.ts
@@ -8,7 +8,8 @@ import {
   generateInstallCommand,
   generateUninstallCommand,
   installDependencies,
-  uninstallDependencies
+  uninstallDependencies,
+  checkOptionalPeerDependencies
 } from '../../src/validators/dependencies'
 
 describe('Dependency Validator', () => {
@@ -155,6 +156,94 @@ describe('Dependency Validator', () => {
       expect(result.valid).toBe(false)
       expect(result.installed).toHaveLength(1)
       expect(result.missing).toContain('@tetherto/wdk-wallet-evm-erc-4337')
+    })
+  })
+
+  describe('checkOptionalPeerDependencies', () => {
+    const writeModule = (name: string, pkg: Record<string, unknown>): string => {
+      const modulePath = path.join(tempDir, 'node_modules', ...name.split('/'))
+      fs.mkdirSync(modulePath, { recursive: true })
+      fs.writeFileSync(
+        path.join(modulePath, 'package.json'),
+        JSON.stringify({ name, version: '1.0.0', ...pkg })
+      )
+      return modulePath
+    }
+
+    it('should report missing peers not marked as optional', () => {
+      const modulePath = writeModule('@tetherto/wdk-wallet-btc', {
+        peerDependencies: { 'some-required-peer': '^1.0.0' }
+      })
+
+      const missing = checkOptionalPeerDependencies(
+        [{ name: '@tetherto/wdk-wallet-btc', path: modulePath, version: '1.0.0', isLocal: false }],
+        tempDir
+      )
+
+      expect(missing).toHaveLength(1)
+      expect(missing[0].name).toBe('some-required-peer')
+      expect(missing[0].sources[0].parent).toBe('@tetherto/wdk-wallet-btc')
+    })
+
+    it('should skip peers marked optional via peerDependenciesMeta', () => {
+      const modulePath = writeModule('@bitcoinerlab/descriptors', {
+        peerDependencies: { '@ledgerhq/ledger-bitcoin': '^0.3.1' },
+        peerDependenciesMeta: { '@ledgerhq/ledger-bitcoin': { optional: true } }
+      })
+
+      const missing = checkOptionalPeerDependencies(
+        [{ name: '@bitcoinerlab/descriptors', path: modulePath, version: '1.0.0', isLocal: false }],
+        tempDir
+      )
+
+      expect(missing).toHaveLength(0)
+    })
+
+    it('should find optional peers declared by transitive dependencies', () => {
+      const btcPath = writeModule('@tetherto/wdk-wallet-btc', {
+        dependencies: { '@bitcoinerlab/descriptors': '^2.0.0' }
+      })
+      writeModule('@bitcoinerlab/descriptors', {
+        peerDependencies: {
+          '@ledgerhq/ledger-bitcoin': '^0.3.1',
+          'some-required-peer': '^1.0.0'
+        },
+        peerDependenciesMeta: { '@ledgerhq/ledger-bitcoin': { optional: true } }
+      })
+
+      const missing = checkOptionalPeerDependencies(
+        [{ name: '@tetherto/wdk-wallet-btc', path: btcPath, version: '1.0.0', isLocal: false }],
+        tempDir
+      )
+
+      expect(missing.map(m => m.name)).toEqual(['some-required-peer'])
+    })
+
+    it('should not report installed peers', () => {
+      const modulePath = writeModule('@tetherto/wdk-wallet-btc', {
+        peerDependencies: { 'some-required-peer': '^1.0.0' }
+      })
+      writeModule('some-required-peer', {})
+
+      const missing = checkOptionalPeerDependencies(
+        [{ name: '@tetherto/wdk-wallet-btc', path: modulePath, version: '1.0.0', isLocal: false }],
+        tempDir
+      )
+
+      expect(missing).toHaveLength(0)
+    })
+
+    it('should skip ignored peer prefixes', () => {
+      const modulePath = writeModule('@tetherto/wdk-wallet-btc', {
+        peerDependencies: { 'react-native': '*', react: '*' }
+      })
+
+      const missing = checkOptionalPeerDependencies(
+        [{ name: '@tetherto/wdk-wallet-btc', path: modulePath, version: '1.0.0', isLocal: false }],
+        tempDir
+      )
+
+      expect(missing).toHaveLength(0)
     })
   })
 


### PR DESCRIPTION
# Description

Fixes `generate` failing (or silently exiting) in projects whose dependency tree contains **optional** peer dependencies that aren't installed — most notably `@tetherto/wdk-wallet-btc → @bitcoinerlab/descriptors → @ledgerhq/ledger-bitcoin` (optional peer, only needed for Ledger hardware signing).

Three changes:

1. **Respect `peerDependenciesMeta.optional` in the peer-dep check.** The scanner treated every missing peer as required and prompted to install it. Peers explicitly marked optional are no longer reported or prompted for. The scan also covers peers declared *only* in `peerDependenciesMeta` with no `peerDependencies` entry (e.g. `follow-redirects` → `debug`).

2. **Defer missing optional peers at pack time.** Even with the prompt fixed, `bare-pack` statically resolves every `require` and failed on the (try/catch-guarded, lazily loaded) Ledger import. Missing optional peers are now passed to `bare-pack --defer`, so resolution moves to runtime where the consuming packages already guard for absence. Opt out with `--no-defer-optional-peers` for apps that actually use those features and want a build-time failure instead. An installed peer always takes precedence — nothing is deferred if the package is present.

3. **Non-TTY safety (the silent-failure bug).** `promptYesNo` used readline unconditionally; under npm's no-TTY postinstall the callback never fired, the event loop drained, and the process exited 0 without generating anything. Prompts now detect the missing TTY and take a default: missing core deps fail (exit 1, with a `--install` hint); missing required peers print the exact manual install command and continue.

Also moved `getPackageList` from the CLI into `src/config/packages.ts` so `generateBundle` can compute the defer list when used programmatically.

**Behavioral note:** previously a missing optional peer prompted and could be installed interactively; now it is deferred by default (with a log line listing what was deferred). An app that genuinely uses Ledger signing discovers the missing package at runtime instead of install time — pass `--no-defer-optional-peers` (or install the peer) to keep build-time strictness.

Verified end-to-end with a fresh project using `"postinstall": "wdk-worklet-bundler generate"` and a 4-network config (btc/spark/evm-4337/tron-gasfree + spark-frost preload): clean `npm install` exits 0 and produces the bundle with `@ledgerhq/ledger-bitcoin`, `bufferutil`, `utf-8-validate`, `debug` deferred; `--no-defer-optional-peers` exits 1 naming the missing package. New unit tests cover the scanner changes (67 tests passing).

## Motivation and Context

`npm install` in consuming repos (RN apps) intermittently produced no bundle: the bundler prompted "install now? [Y/n]" for `@ledgerhq/ledger-bitcoin` during postinstall, and with no TTY it exited 0 without building — a silent failure. The workaround was adding `@ledgerhq/ledger-bitcoin` to the app's `package.json`, which makes no sense today: there is no Ledger support in the btc package yet, and the peer is correctly marked optional upstream. Consumers can now drop that workaround.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

