### PR TITLE
Release: v1.0.0-beta.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-worklet-bundler",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-worklet-bundler",
-      "version": "1.0.0-beta.5",
+      "version": "1.0.0-beta.6",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-worklet-bundler",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "description": "CLI tool for generating WDK worklet bundles",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.6

### Changes since v1.0.0-beta.5
- fix: skip and defer optional peer dependencies for bare installs (#34)
- docs: update README for peer deferring (#35)

### Dependency updates
- npm audit fix applied (no non-breaking fixes available)