### PR TITLE
Release: v1.0.0-beta.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-worklet-bundler",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-worklet-bundler",
-      "version": "1.0.0-beta.6",
+      "version": "1.0.0-beta.7",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-worklet-bundler",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "description": "CLI tool for generating WDK worklet bundles",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.7

### Changes since v1.0.0-beta.6
- fix: don't defer optional peers that are present nested (breaks Spark when BTC peer nested) (#38)

### Dependency updates
- none (version-only release)
