### PR TITLE
Release: v1.0.0-beta.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-worklet-bundler",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-worklet-bundler",
-      "version": "1.0.0-beta.9",
+      "version": "1.0.0-beta.10",
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-worklet-bundler",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "description": "CLI tool for generating WDK worklet bundles",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.10

### Changes since v1.0.0-beta.9
- Replace hand-rolled bundle parsing with `bare-bundle` (#1)
- ESM/CJS conversion fixes, `validateBundle` CI, and more robust bundle testing (#39)
- Security dependency updates (#45)

### Dependency updates
- None (version-only release)